### PR TITLE
Migrate multi-profile support to upstream contextId routing

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -698,44 +698,48 @@ async function connect() {
   } catch {
     return;
   }
+  let thisWs;
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    thisWs = new WebSocket(DAEMON_WS_URL);
+    ws = thisWs;
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
   }
-  ws.onopen = () => {
+  thisWs.onopen = () => {
+    if (ws !== thisWs) return;
     console.log("[opencli] Connected to daemon");
     reconnectAttempts = 0;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
-    ws?.send(JSON.stringify({
+    thisWs.send(JSON.stringify({
       type: "hello",
       contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
       compatRange: ">=1.7.0"
     }));
   };
-  ws.onmessage = async (event) => {
+  thisWs.onmessage = async (event) => {
     try {
       const command = JSON.parse(event.data);
       const result = await handleCommand(command);
-      ws?.send(JSON.stringify(result));
+      thisWs.send(JSON.stringify(result));
     } catch (err) {
       console.error("[opencli] Message handling error:", err);
     }
   };
-  ws.onclose = () => {
+  thisWs.onclose = () => {
+    if (ws !== thisWs) return;
     console.log("[opencli] Disconnected from daemon");
     ws = null;
     scheduleReconnect();
   };
-  ws.onerror = () => {
-    ws?.close();
+  thisWs.onerror = () => {
+    thisWs.close();
   };
 }
 const MAX_EAGER_ATTEMPTS = 6;

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -26,14 +26,20 @@ type MockTabGroup = {
 class MockWebSocket {
   static OPEN = 1;
   static CONNECTING = 0;
+  static instances: MockWebSocket[] = [];
   readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(_url: string) {}
-  send(_data: string): void {}
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
   close(): void {
     this.onclose?.();
   }
@@ -189,6 +195,7 @@ describe('background tab isolation', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.useRealTimers();
+    MockWebSocket.instances = [];
     vi.stubGlobal('WebSocket', MockWebSocket);
   });
 
@@ -587,6 +594,33 @@ describe('background tab isolation', () => {
       expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({
         contextId: 'abc123xy',
       }));
+    });
+  });
+
+  it('keeps the active daemon connection when a superseded WebSocket closes later', async () => {
+    const { chrome } = createChromeMock();
+    vi.stubGlobal('chrome', chrome);
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+
+    await import('./background');
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+    const firstWs = MockWebSocket.instances[0];
+    firstWs.readyState = 3;
+
+    const onAlarmListener = chrome.alarms.onAlarm.addListener.mock.calls[0][0];
+    await onAlarmListener({ name: 'keepalive' });
+    await vi.waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+    const secondWs = MockWebSocket.instances[1];
+
+    firstWs.onclose?.();
+    secondWs.onmessage?.({ data: JSON.stringify({ id: 'sessions-after-stale-close', action: 'sessions' }) });
+
+    await vi.waitFor(() => {
+      expect(secondWs.sent.some((entry) => entry.includes('sessions-after-stale-close'))).toBe(true);
     });
   });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -100,16 +100,19 @@ async function connect(): Promise<void> {
     return; // daemon not running — skip WebSocket to avoid console noise
   }
 
+  let thisWs: WebSocket;
   try {
     const contextId = await getCurrentContextId();
-    ws = new WebSocket(DAEMON_WS_URL);
+    thisWs = new WebSocket(DAEMON_WS_URL);
+    ws = thisWs;
     currentContextId = contextId;
   } catch {
     scheduleReconnect();
     return;
   }
 
-  ws.onopen = () => {
+  thisWs.onopen = () => {
+    if (ws !== thisWs) return;
     console.log('[opencli] Connected to daemon');
     reconnectAttempts = 0; // Reset on successful connection
     if (reconnectTimer) {
@@ -117,7 +120,7 @@ async function connect(): Promise<void> {
       reconnectTimer = null;
     }
     // Send version + compatibility range so the daemon can report mismatches to the CLI
-    ws?.send(JSON.stringify({
+    thisWs.send(JSON.stringify({
       type: 'hello',
       contextId: currentContextId,
       version: chrome.runtime.getManifest().version,
@@ -125,24 +128,25 @@ async function connect(): Promise<void> {
     }));
   };
 
-  ws.onmessage = async (event) => {
+  thisWs.onmessage = async (event) => {
     try {
       const command = JSON.parse(event.data as string) as Command;
       const result = await handleCommand(command);
-      ws?.send(JSON.stringify(result));
+      thisWs.send(JSON.stringify(result));
     } catch (err) {
       console.error('[opencli] Message handling error:', err);
     }
   };
 
-  ws.onclose = () => {
+  thisWs.onclose = () => {
+    if (ws !== thisWs) return;
     console.log('[opencli] Disconnected from daemon');
     ws = null;
     scheduleReconnect();
   };
 
-  ws.onerror = () => {
-    ws?.close();
+  thisWs.onerror = () => {
+    thisWs.close();
   };
 }
 


### PR DESCRIPTION
## Summary

Implements the multi-profile migration decision from #6 by rebasing the work onto upstream's `contextId` Browser Bridge model and keeping only the minimal local fix we still need.

This PR intentionally does **not** carry forward the old custom multi-profile routing stack:

- no custom `profileId` / `extensions` routing
- no custom `daemon-routing.ts` / `config.ts`
- no popup rename / `profileLabel` sync-storage UX
- no broad daemon/client/CLI routing delta

The only code delta is the stale WebSocket close guard in the extension background connection lifecycle.

## What changed

- Captures each daemon WebSocket as `thisWs` inside `connect()`.
- Binds `onopen`, `onmessage`, `onclose`, and `onerror` to that specific instance.
- Ignores stale `onopen` / `onclose` callbacks when a newer WebSocket has already replaced the module-level `ws` pointer.
- Adds a regression test where an old daemon WebSocket closes after a newer connection exists, then verifies the newer connection can still return command responses.
- Rebuilds `extension/dist/background.js`.

## Why

Upstream now has the correct long-term multi-profile architecture using:

- `contextId`
- `extensionProfiles`
- `src/browser/profile.ts`
- `opencli profile list`
- `opencli profile rename <contextId> <alias>`
- `opencli profile use <profile>`
- `--profile <alias-or-contextId>` / `OPENCLI_PROFILE`

Keeping our old custom routing caused repeated merge conflicts in high-churn files. This PR reduces the migration to a small, low-conflict patch while preserving the real connection bug fix.

## Verification

```bash
npx vitest run --project extension extension/src/background.test.ts
npm run typecheck -- --pretty false
npm --prefix extension run typecheck
npm --prefix extension run build
```

All passed locally.

## Follow-up docs

Per #6, BillMend operation docs should be updated after this lands so account-sensitive examples use explicit upstream aliases, for example:

```bash
opencli --profile Geoffrey reddit ...
opencli --profile yaya facebook ...
```

Aliases should be configured with:

```bash
opencli profile list
opencli profile rename <contextId> Geoffrey
opencli profile rename <contextId> yaya
```

Closes #6.
