### PR TITLE
feat(boss): add job-seeker side for chatlist and chatmsg

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3484,7 +3484,7 @@
   {
     "site": "boss",
     "name": "chatlist",
-    "description": "BOSS直聘查看聊天列表（招聘端）",
+    "description": "BOSS直聘查看聊天列表（招聘端/求职端）",
     "access": "read",
     "domain": "www.zhipin.com",
     "strategy": "cookie",
@@ -3509,12 +3509,26 @@
         "type": "str",
         "default": "0",
         "required": false,
-        "help": "Filter by job ID (0=all)"
+        "help": "Filter by job ID (0=all, boss side only)"
+      },
+      {
+        "name": "side",
+        "type": "str",
+        "default": "auto",
+        "required": false,
+        "help": "Identity side: auto (default), boss (recruiter), or geek (job-seeker)",
+        "choices": [
+          "auto",
+          "boss",
+          "geek"
+        ]
       }
     ],
     "columns": [
       "name",
+      "company",
       "job",
+      "title",
       "last_msg",
       "last_time",
       "uid",
@@ -3528,7 +3542,7 @@
   {
     "site": "boss",
     "name": "chatmsg",
-    "description": "BOSS直聘查看与候选人的聊天消息",
+    "description": "BOSS直聘查看聊天消息历史（招聘端/求职端）",
     "access": "read",
     "domain": "www.zhipin.com",
     "strategy": "cookie",
@@ -3547,6 +3561,18 @@
         "default": 1,
         "required": false,
         "help": "Page number"
+      },
+      {
+        "name": "side",
+        "type": "str",
+        "default": "auto",
+        "required": false,
+        "help": "Identity side: auto (default), boss (recruiter), or geek (job-seeker)",
+        "choices": [
+          "auto",
+          "boss",
+          "geek"
+        ]
       }
     ],
     "columns": [

--- a/clis/boss/chatlist.js
+++ b/clis/boss/chatlist.js
@@ -26,10 +26,11 @@ function mapBossRow(f) {
 async function buildGeekRows(page, limit) {
     const encryptSystemId = await readEncryptSystemId(page);
     const labelList = await fetchGeekFriendLabelList(page, { encryptSystemId });
-    const friendIds = labelList.map((f) => f.friendId).filter(Boolean);
+    const slicedLabels = labelList.slice(0, limit);
+    const friendIds = slicedLabels.map((f) => f.friendId).filter(Boolean);
     const enriched = await fetchGeekFriendInfoList(page, friendIds);
     const enrichMap = new Map(enriched.map((f) => [String(f.friendId ?? f.uid), f]));
-    return labelList.slice(0, limit).map((f) => {
+    return slicedLabels.map((f) => {
         const e = enrichMap.get(String(f.friendId)) || {};
         return {
             name: e.name || f.name || '',

--- a/clis/boss/chatlist.js
+++ b/clis/boss/chatlist.js
@@ -1,10 +1,54 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requirePage, navigateToChat, fetchFriendList } from './utils.js';
+import {
+    requirePage, navigateToChat, navigateToGeekChat,
+    fetchFriendList, fetchGeekFriendLabelList, fetchGeekFriendInfoList,
+    readEncryptSystemId, assertOk, IDENTITY_MISMATCH_CODE,
+} from './utils.js';
+
+function formatMsgTime(ms) {
+    if (!ms) return '';
+    return new Date(ms).toLocaleString('zh-CN');
+}
+
+function mapBossRow(f) {
+    return {
+        name: f.name || '',
+        company: '',
+        job: f.jobName || '',
+        title: '',
+        last_msg: f.lastMessageInfo?.text || '',
+        last_time: f.lastTime || '',
+        uid: f.encryptUid || '',
+        security_id: f.securityId || '',
+    };
+}
+
+async function buildGeekRows(page, limit) {
+    const encryptSystemId = await readEncryptSystemId(page);
+    const labelList = await fetchGeekFriendLabelList(page, { encryptSystemId });
+    const friendIds = labelList.map((f) => f.friendId).filter(Boolean);
+    const enriched = await fetchGeekFriendInfoList(page, friendIds);
+    const enrichMap = new Map(enriched.map((f) => [String(f.friendId ?? f.uid), f]));
+    return labelList.slice(0, limit).map((f) => {
+        const e = enrichMap.get(String(f.friendId)) || {};
+        return {
+            name: e.name || f.name || '',
+            company: e.brandName || f.brandName || '',
+            job: e.jobName || f.jobName || '',
+            title: e.bossTitle || f.bossTitle || '',
+            last_msg: e.lastMessageInfo?.showText || e.lastMsg || f.lastMsg || '',
+            last_time: e.lastTime || formatMsgTime(e.lastMessageInfo?.msgTime) || formatMsgTime(f.updateTime) || '',
+            uid: e.encryptUid || f.encryptFriendId || String(e.uid ?? e.friendId ?? f.friendId ?? ''),
+            security_id: e.securityId || '',
+        };
+    });
+}
+
 cli({
     site: 'boss',
     name: 'chatlist',
     access: 'read',
-    description: 'BOSS直聘查看聊天列表（招聘端）',
+    description: 'BOSS直聘查看聊天列表（招聘端/求职端）',
     domain: 'www.zhipin.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
@@ -12,23 +56,43 @@ cli({
     args: [
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
         { name: 'limit', type: 'int', default: 20, help: 'Number of results' },
-        { name: 'job-id', default: '0', help: 'Filter by job ID (0=all)' },
+        { name: 'job-id', default: '0', help: 'Filter by job ID (0=all, boss side only)' },
+        { name: 'side', default: 'auto', choices: ['auto', 'boss', 'geek'], help: 'Identity side: auto (default), boss (recruiter), or geek (job-seeker)' },
     ],
-    columns: ['name', 'job', 'last_msg', 'last_time', 'uid', 'security_id'],
+    columns: ['name', 'company', 'job', 'title', 'last_msg', 'last_time', 'uid', 'security_id'],
     func: async (page, kwargs) => {
         requirePage(page);
+        const limit = kwargs.limit || 20;
+        const side = kwargs.side || 'auto';
+
+        if (side === 'boss') {
+            await navigateToChat(page);
+            const friends = await fetchFriendList(page, {
+                pageNum: kwargs.page || 1,
+                jobId: kwargs['job-id'] || '0',
+            });
+            return friends.slice(0, limit).map(mapBossRow);
+        }
+
+        if (side === 'geek') {
+            await navigateToGeekChat(page);
+            return await buildGeekRows(page, limit);
+        }
+
+        // auto: try recruiter first, fall back to geek on identity mismatch
         await navigateToChat(page);
-        const friends = await fetchFriendList(page, {
+        const bossResult = await fetchFriendList(page, {
             pageNum: kwargs.page || 1,
             jobId: kwargs['job-id'] || '0',
+            allowNonZero: true,
         });
-        return friends.slice(0, kwargs.limit || 20).map((f) => ({
-            name: f.name || '',
-            job: f.jobName || '',
-            last_msg: f.lastMessageInfo?.text || '',
-            last_time: f.lastTime || '',
-            uid: f.encryptUid || '',
-            security_id: f.securityId || '',
-        }));
+        if (Array.isArray(bossResult)) {
+            return bossResult.slice(0, limit).map(mapBossRow);
+        }
+        if (bossResult.code === IDENTITY_MISMATCH_CODE) {
+            await navigateToGeekChat(page);
+            return await buildGeekRows(page, limit);
+        }
+        assertOk(bossResult);
     },
 });

--- a/clis/boss/chatlist.test.js
+++ b/clis/boss/chatlist.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './chatlist.js';
+
+const BOSS_FRIEND = {
+    name: '张三',
+    jobName: '后端工程师',
+    lastMessageInfo: { text: '你好' },
+    lastTime: '2024-01-01 10:00',
+    encryptUid: 'enc-boss-uid',
+    securityId: 'boss-sec-id',
+};
+
+const GEEK_LABEL_FRIEND = {
+    friendId: 12345,
+    name: '李四',
+    brandName: '字节跳动',
+    jobName: '产品经理',
+    bossTitle: 'HR',
+    lastMsg: '感谢投递',
+    updateTime: 1704067200000,
+    encryptFriendId: 'enc-geek-uid',
+};
+
+const GEEK_ENRICHED = {
+    friendId: 12345,
+    uid: 99999,
+    name: '李四',
+    brandName: '字节跳动',
+    jobName: '产品经理',
+    bossTitle: 'HR总监',
+    encryptUid: 'enc-geek-uid',
+    securityId: 'geek-sec-id',
+    lastMessageInfo: { showText: '感谢投递', msgTime: 1704067200000 },
+    lastTime: '2024-01-01',
+};
+
+function createPageMock(evaluateImpl) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(evaluateImpl),
+    };
+}
+
+describe('boss chatlist', () => {
+    const command = getRegistry().get('boss/chatlist');
+
+    it('--side boss preserves existing behavior with 8-column output', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('getBossFriendListV2')) {
+                return { code: 0, zpData: { friendList: [BOSS_FRIEND] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { page: 1, limit: 20, 'job-id': '0', side: 'boss' });
+        expect(page.goto).toHaveBeenCalledWith(expect.stringContaining('/web/chat/index'));
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            name: '张三',
+            company: '',
+            job: '后端工程师',
+            title: '',
+            last_msg: '你好',
+            uid: 'enc-boss-uid',
+            security_id: 'boss-sec-id',
+        });
+    });
+
+    it('--side geek maps enriched getGeekFriendList data into 8 columns', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_LABEL_FRIEND] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_ENRICHED] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { page: 1, limit: 20, 'job-id': '0', side: 'geek' });
+        expect(page.goto).toHaveBeenCalledWith(expect.stringContaining('/web/geek/chat'));
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            name: '李四',
+            company: '字节跳动',
+            job: '产品经理',
+            title: 'HR总监',
+            uid: 'enc-geek-uid',
+            security_id: 'geek-sec-id',
+        });
+    });
+
+    it('--side geek falls back to label fields when enrichment has no match', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_LABEL_FRIEND] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { page: 1, limit: 20, 'job-id': '0', side: 'geek' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].name).toBe('李四');
+        expect(rows[0].company).toBe('字节跳动');
+        expect(rows[0].security_id).toBe('');
+    });
+
+    it('--side auto falls back to geek when recruiter returns code 24', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('getBossFriendListV2')) {
+                return { code: 24, message: '请切换身份后再试' };
+            }
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_LABEL_FRIEND] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_ENRICHED] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { page: 1, limit: 20, 'job-id': '0', side: 'auto' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].company).toBe('字节跳动');
+        expect(page.goto).toHaveBeenCalledWith(expect.stringContaining('/web/geek/chat'));
+    });
+
+    it('--side auto uses recruiter results when code 0 and does not call geek API', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('getBossFriendListV2')) {
+                return { code: 0, zpData: { friendList: [BOSS_FRIEND] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { page: 1, limit: 20, 'job-id': '0', side: 'auto' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].name).toBe('张三');
+        const evaluateCalls = page.evaluate.mock.calls.map((c) => c[0]);
+        expect(evaluateCalls.some((s) => s.includes('geekFilterByLabel'))).toBe(false);
+    });
+
+    it('registers --side as a choices-constrained arg defaulting to auto', () => {
+        const sideArg = command.args.find((a) => a.name === 'side');
+        expect(sideArg?.choices).toEqual(['auto', 'boss', 'geek']);
+        expect(sideArg?.default).toBe('auto');
+    });
+});

--- a/clis/boss/chatmsg.js
+++ b/clis/boss/chatmsg.js
@@ -1,10 +1,61 @@
 import { cli, Strategy } from '@jackwener/opencli/registry';
-import { requirePage, navigateToChat, bossFetch, findFriendByUid } from './utils.js';
+import {
+    requirePage, navigateToChat, navigateToGeekChat,
+    bossFetch, findFriendByUid, findGeekFriendByUid,
+    fetchGeekHistoryMsg, readEncryptSystemId,
+    assertOk, IDENTITY_MISMATCH_CODE,
+} from './utils.js';
+
+const TYPE_MAP = {
+    1: '文本', 2: '图片', 3: '招呼', 4: '简历', 5: '系统',
+    6: '名片', 7: '语音', 8: '视频', 9: '表情',
+};
+
+function mapBossMsg(m, friend) {
+    const fromObj = m.from || {};
+    const isSelf = typeof fromObj === 'object' ? fromObj.uid !== friend.uid : false;
+    return {
+        from: isSelf ? '我' : (typeof fromObj === 'object' ? fromObj.name : friend.name),
+        type: TYPE_MAP[m.type] || `其他(${m.type})`,
+        text: m.text || m.body?.text || '',
+        time: m.time ? new Date(m.time).toLocaleString('zh-CN') : '',
+    };
+}
+
+function mapGeekMsg(m) {
+    return {
+        from: m.received ? '对方' : '我',
+        type: TYPE_MAP[m.type] || `其他(${m.type})`,
+        text: m.text || m.body?.text || m.body?.content || m.body?.showText ||
+            JSON.stringify(m.body || {}).slice(0, 120),
+        time: m.time ? new Date(m.time).toLocaleString('zh-CN') : '',
+    };
+}
+
+async function bossChatMsg(page, kwargs) {
+    const friend = await findFriendByUid(page, kwargs.uid);
+    if (!friend) throw new Error('未找到该候选人');
+    const gid = friend.uid;
+    const securityId = encodeURIComponent(friend.securityId);
+    const msgUrl = `https://www.zhipin.com/wapi/zpchat/boss/historyMsg?gid=${gid}&securityId=${securityId}&page=${kwargs.page}&c=20&src=0`;
+    const msgData = await bossFetch(page, msgUrl);
+    const messages = msgData.zpData?.messages || msgData.zpData?.historyMsgList || [];
+    return messages.map((m) => mapBossMsg(m, friend));
+}
+
+async function geekChatMsg(page, kwargs, encryptSystemId) {
+    const friend = await findGeekFriendByUid(page, kwargs.uid, { encryptSystemId });
+    if (!friend) throw new Error('未找到该聊天（geek 侧）');
+    if (!friend.securityId) throw new Error('该聊天缺少 securityId，无法获取历史消息');
+    const messages = await fetchGeekHistoryMsg(page, friend, { page: kwargs.page });
+    return messages.map(mapGeekMsg);
+}
+
 cli({
     site: 'boss',
     name: 'chatmsg',
     access: 'read',
-    description: 'BOSS直聘查看与候选人的聊天消息',
+    description: 'BOSS直聘查看聊天消息历史（招聘端/求职端）',
     domain: 'www.zhipin.com',
     strategy: Strategy.COOKIE,
     navigateBefore: false,
@@ -12,32 +63,47 @@ cli({
     args: [
         { name: 'uid', required: true, positional: true, help: 'Encrypted UID (from chatlist)' },
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
+        { name: 'side', default: 'auto', choices: ['auto', 'boss', 'geek'], help: 'Identity side: auto (default), boss (recruiter), or geek (job-seeker)' },
     ],
     columns: ['from', 'type', 'text', 'time'],
     func: async (page, kwargs) => {
         requirePage(page);
+        const side = kwargs.side || 'auto';
+
+        if (side === 'boss') {
+            await navigateToChat(page);
+            return await bossChatMsg(page, kwargs);
+        }
+
+        if (side === 'geek') {
+            await navigateToGeekChat(page);
+            const encryptSystemId = await readEncryptSystemId(page);
+            return await geekChatMsg(page, kwargs, encryptSystemId);
+        }
+
+        // auto: try recruiter first, fall back to geek when not found or identity mismatch
         await navigateToChat(page);
-        const friend = await findFriendByUid(page, kwargs.uid);
-        if (!friend)
-            throw new Error('未找到该候选人');
-        const gid = friend.uid;
-        const securityId = encodeURIComponent(friend.securityId);
-        const msgUrl = `https://www.zhipin.com/wapi/zpchat/boss/historyMsg?gid=${gid}&securityId=${securityId}&page=${kwargs.page}&c=20&src=0`;
-        const msgData = await bossFetch(page, msgUrl);
-        const TYPE_MAP = {
-            1: '文本', 2: '图片', 3: '招呼', 4: '简历', 5: '系统',
-            6: '名片', 7: '语音', 8: '视频', 9: '表情',
-        };
-        const messages = msgData.zpData?.messages || msgData.zpData?.historyMsgList || [];
-        return messages.map((m) => {
-            const fromObj = m.from || {};
-            const isSelf = typeof fromObj === 'object' ? fromObj.uid !== friend.uid : false;
-            return {
-                from: isSelf ? '我' : (typeof fromObj === 'object' ? fromObj.name : friend.name),
-                type: TYPE_MAP[m.type] || '其他(' + m.type + ')',
-                text: m.text || m.body?.text || '',
-                time: m.time ? new Date(m.time).toLocaleString('zh-CN') : '',
-            };
-        });
+        const bossResult = await findFriendByUid(page, kwargs.uid, { allowNonZero: true });
+        if (bossResult?.friend) {
+            const friend = bossResult.friend;
+            const gid = friend.uid;
+            const securityId = encodeURIComponent(friend.securityId);
+            const msgUrl = `https://www.zhipin.com/wapi/zpchat/boss/historyMsg?gid=${gid}&securityId=${securityId}&page=${kwargs.page}&c=20&src=0`;
+            const msgData = await bossFetch(page, msgUrl);
+            const messages = msgData.zpData?.messages || msgData.zpData?.historyMsgList || [];
+            return messages.map((m) => mapBossMsg(m, friend));
+        }
+        // Not found in recruiter list or identity mismatch — check for hard errors first
+        if (bossResult?.code && bossResult.code !== 0 && bossResult.code !== IDENTITY_MISMATCH_CODE) {
+            assertOk(bossResult);
+        }
+        // Fall back to geek side
+        await navigateToGeekChat(page);
+        const encryptSystemId = await readEncryptSystemId(page);
+        const geekFriend = await findGeekFriendByUid(page, kwargs.uid, { encryptSystemId });
+        if (!geekFriend) throw new Error('uid 在招聘端与求职端聊天列表中均未找到');
+        if (!geekFriend.securityId) throw new Error('该聊天缺少 securityId，无法获取历史消息');
+        const messages = await fetchGeekHistoryMsg(page, geekFriend, { page: kwargs.page });
+        return messages.map(mapGeekMsg);
     },
 });

--- a/clis/boss/chatmsg.js
+++ b/clis/boss/chatmsg.js
@@ -22,9 +22,11 @@ function mapBossMsg(m, friend) {
     };
 }
 
-function mapGeekMsg(m) {
+function mapGeekMsg(m, friend) {
+    const fromUid = m.from && m.from.uid;
+    const isFromBoss = fromUid != null && String(fromUid) === String(friend.uid);
     return {
-        from: m.received ? '对方' : '我',
+        from: isFromBoss ? '对方' : '我',
         type: TYPE_MAP[m.type] || `其他(${m.type})`,
         text: m.text || m.body?.text || m.body?.content || m.body?.showText ||
             JSON.stringify(m.body || {}).slice(0, 120),
@@ -48,7 +50,7 @@ async function geekChatMsg(page, kwargs, encryptSystemId) {
     if (!friend) throw new Error('未找到该聊天（geek 侧）');
     if (!friend.securityId) throw new Error('该聊天缺少 securityId，无法获取历史消息');
     const messages = await fetchGeekHistoryMsg(page, friend, { page: kwargs.page });
-    return messages.map(mapGeekMsg);
+    return messages.map((m) => mapGeekMsg(m, friend));
 }
 
 cli({
@@ -98,6 +100,6 @@ cli({
         if (!geekFriend) throw new Error('uid 在招聘端与求职端聊天列表中均未找到');
         if (!geekFriend.securityId) throw new Error('该聊天缺少 securityId，无法获取历史消息');
         const messages = await fetchGeekHistoryMsg(page, geekFriend, { page: kwargs.page });
-        return messages.map(mapGeekMsg);
+        return messages.map((m) => mapGeekMsg(m, geekFriend));
     },
 });

--- a/clis/boss/chatmsg.js
+++ b/clis/boss/chatmsg.js
@@ -32,8 +32,8 @@ function mapGeekMsg(m) {
     };
 }
 
-async function bossChatMsg(page, kwargs) {
-    const friend = await findFriendByUid(page, kwargs.uid);
+async function bossChatMsg(page, kwargs, existingFriend) {
+    const friend = existingFriend ?? await findFriendByUid(page, kwargs.uid);
     if (!friend) throw new Error('未找到该候选人');
     const gid = friend.uid;
     const securityId = encodeURIComponent(friend.securityId);
@@ -85,15 +85,9 @@ cli({
         await navigateToChat(page);
         const bossResult = await findFriendByUid(page, kwargs.uid, { allowNonZero: true });
         if (bossResult?.friend) {
-            const friend = bossResult.friend;
-            const gid = friend.uid;
-            const securityId = encodeURIComponent(friend.securityId);
-            const msgUrl = `https://www.zhipin.com/wapi/zpchat/boss/historyMsg?gid=${gid}&securityId=${securityId}&page=${kwargs.page}&c=20&src=0`;
-            const msgData = await bossFetch(page, msgUrl);
-            const messages = msgData.zpData?.messages || msgData.zpData?.historyMsgList || [];
-            return messages.map((m) => mapBossMsg(m, friend));
+            return await bossChatMsg(page, kwargs, bossResult.friend);
         }
-        // Not found in recruiter list or identity mismatch — check for hard errors first
+        // Not found or identity mismatch — check for hard errors before falling back
         if (bossResult?.code && bossResult.code !== 0 && bossResult.code !== IDENTITY_MISMATCH_CODE) {
             assertOk(bossResult);
         }

--- a/clis/boss/chatmsg.test.js
+++ b/clis/boss/chatmsg.test.js
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getRegistry } from '@jackwener/opencli/registry';
+import './chatmsg.js';
+
+const BOSS_FRIEND = {
+    uid: 12345,
+    encryptUid: 'enc-boss-uid',
+    securityId: 'boss-sec-id',
+    name: '候选人甲',
+};
+const BOSS_MSGS = [
+    { type: 1, text: 'Hello', from: { uid: 99999, name: 'HR' }, time: 1704067200000 },
+    { type: 1, text: '感谢', from: { uid: 12345, name: '候选人甲' }, time: 1704067201000 },
+];
+
+const GEEK_FRIEND_LABEL = {
+    friendId: 11111,
+    encryptFriendId: 'enc-geek-uid',
+    name: 'Boss张',
+    brandName: '公司A',
+};
+const GEEK_FRIEND_ENRICHED = {
+    friendId: 11111,
+    uid: 67890,
+    encryptUid: 'enc-geek-uid',
+    securityId: 'geek-sec-id',
+    name: 'Boss张',
+};
+const GEEK_MSGS = [
+    { type: 1, text: '欢迎投递', received: true, time: 1704067200000 },
+    { type: 1, text: '谢谢', received: false, time: 1704067201000 },
+];
+
+function createPageMock(evaluateImpl) {
+    return {
+        goto: vi.fn().mockResolvedValue(undefined),
+        wait: vi.fn().mockResolvedValue(undefined),
+        evaluate: vi.fn().mockImplementation(evaluateImpl),
+    };
+}
+
+describe('boss chatmsg', () => {
+    const command = getRegistry().get('boss/chatmsg');
+
+    it('--side boss preserves existing behavior', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('getBossFriendListV2')) {
+                return { code: 0, zpData: { friendList: [BOSS_FRIEND] } };
+            }
+            if (script.includes('boss/historyMsg')) {
+                return { code: 0, zpData: { messages: BOSS_MSGS } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { uid: 'enc-boss-uid', page: 1, side: 'boss' });
+        expect(page.goto).toHaveBeenCalledWith(expect.stringContaining('/web/chat/index'));
+        expect(rows).toHaveLength(2);
+        expect(rows[0].from).toBe('我');
+        expect(rows[1].from).toBe('候选人甲');
+    });
+
+    it('--side geek calls historyMsg with bossId, securityId, page, c=20, src=0', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_FRIEND_LABEL] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
+            }
+            if (script.includes('geek/historyMsg')) {
+                return { code: 0, zpData: { messages: GEEK_MSGS } };
+            }
+            return {};
+        });
+        await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek' });
+        const historyScript = page.evaluate.mock.calls.find((c) => c[0].includes('geek/historyMsg'))?.[0];
+        expect(historyScript).toBeDefined();
+        expect(historyScript).toContain('bossId=67890');
+        expect(historyScript).toContain('securityId=');
+        expect(historyScript).toContain('page=1');
+        expect(historyScript).toContain('c=20');
+        expect(historyScript).toContain('src=0');
+    });
+
+    it('--side geek maps received:true to 对方 and received:false to 我', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_FRIEND_LABEL] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
+            }
+            if (script.includes('geek/historyMsg')) {
+                return { code: 0, zpData: { messages: GEEK_MSGS } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek' });
+        expect(rows[0].from).toBe('对方');
+        expect(rows[1].from).toBe('我');
+    });
+
+    it('non-text message body does not crash and produces truncated JSON', async () => {
+        const nonTextMsg = { type: 99, received: true, time: 1704067200000, body: { action: 'resume_request', detail: 'X' } };
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_FRIEND_LABEL] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
+            }
+            if (script.includes('geek/historyMsg')) {
+                return { code: 0, zpData: { messages: [nonTextMsg] } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek' });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].text).toContain('resume_request');
+    });
+
+    it('--side auto falls back to geek when recruiter returns code 24', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('getBossFriendListV2')) {
+                return { code: 24, message: '请切换身份后再试' };
+            }
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [GEEK_FRIEND_LABEL] } };
+            }
+            if (script.includes('getGeekFriendList.json')) {
+                return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
+            }
+            if (script.includes('geek/historyMsg')) {
+                return { code: 0, zpData: { messages: GEEK_MSGS } };
+            }
+            return {};
+        });
+        const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'auto' });
+        expect(rows).toHaveLength(2);
+        expect(rows[0].from).toBe('对方');
+    });
+
+    it('--side geek throws when uid is not found in geek chat list', async () => {
+        const page = createPageMock(async (script) => {
+            if (script.includes('document.cookie')) return 'test-enc-sys-id';
+            if (script.includes('geekFilterByLabel')) {
+                return { code: 0, zpData: { friendList: [] } };
+            }
+            return {};
+        });
+        await expect(
+            command.func(page, { uid: 'unknown-uid', page: 1, side: 'geek' })
+        ).rejects.toThrow('未找到该聊天（geek 侧）');
+    });
+});

--- a/clis/boss/chatmsg.test.js
+++ b/clis/boss/chatmsg.test.js
@@ -27,8 +27,8 @@ const GEEK_FRIEND_ENRICHED = {
     name: 'Boss张',
 };
 const GEEK_MSGS = [
-    { type: 1, text: '欢迎投递', received: true, time: 1704067200000 },
-    { type: 1, text: '谢谢', received: false, time: 1704067201000 },
+    { type: 1, text: '欢迎投递', received: true, time: 1704067200000, from: { uid: 67890, name: 'Boss张' } },
+    { type: 1, text: '谢谢', received: true, time: 1704067201000, from: { uid: 99999, name: '我' } },
 ];
 
 function createPageMock(evaluateImpl) {
@@ -83,7 +83,13 @@ describe('boss chatmsg', () => {
         expect(historyScript).toContain('src=0');
     });
 
-    it('--side geek maps received:true to 对方 and received:false to 我', async () => {
+    it('--side geek uses from.uid to determine direction, not received flag', async () => {
+        // Both messages have received:true (mirrors real geek historyMsg API behaviour)
+        // Direction is determined by whether m.from.uid matches the boss's uid (67890)
+        const msgsAllReceived = [
+            { type: 1, text: '欢迎投递', received: true, time: 1704067200000, from: { uid: 67890, name: 'Boss张' } },
+            { type: 1, text: '谢谢', received: true, time: 1704067201000, from: { uid: 99999, name: '我' } },
+        ];
         const page = createPageMock(async (script) => {
             if (script.includes('document.cookie')) return 'test-enc-sys-id';
             if (script.includes('geekFilterByLabel')) {
@@ -93,12 +99,14 @@ describe('boss chatmsg', () => {
                 return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
             }
             if (script.includes('geek/historyMsg')) {
-                return { code: 0, zpData: { messages: GEEK_MSGS } };
+                return { code: 0, zpData: { messages: msgsAllReceived } };
             }
             return {};
         });
         const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek' });
+        // from.uid=67890 matches friend.uid=67890 → boss sent it → '对方'
         expect(rows[0].from).toBe('对方');
+        // from.uid=99999 does not match → geek sent it → '我'
         expect(rows[1].from).toBe('我');
     });
 

--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -95,7 +95,8 @@ export async function fetchFriendList(page, opts = {}) {
     const pageNum = opts.pageNum ?? 1;
     const jobId = opts.jobId ?? '0';
     const url = `https://${BOSS_DOMAIN}/wapi/zprelation/friend/getBossFriendListV2.json?page=${pageNum}&status=0&jobId=${jobId}`;
-    const data = await bossFetch(page, url);
+    const data = await bossFetch(page, url, { allowNonZero: opts.allowNonZero });
+    if (opts.allowNonZero && data.code !== 0) return data;
     return data.zpData?.friendList || [];
 }
 /**
@@ -115,10 +116,14 @@ export async function findFriendByUid(page, encryptUid, opts = {}) {
     const checkGreetList = opts.checkGreetList ?? false;
     // Search friend list pages
     for (let p = 1; p <= maxPages; p++) {
-        const friends = await fetchFriendList(page, { pageNum: p });
+        const result = await fetchFriendList(page, { pageNum: p, allowNonZero: opts.allowNonZero });
+        if (opts.allowNonZero && !Array.isArray(result)) {
+            return { friend: null, code: result.code };
+        }
+        const friends = Array.isArray(result) ? result : [];
         const found = friends.find((f) => f.encryptUid === encryptUid);
         if (found)
-            return found;
+            return opts.allowNonZero ? { friend: found, code: 0 } : found;
         if (friends.length === 0)
             break;
     }
@@ -127,9 +132,9 @@ export async function findFriendByUid(page, encryptUid, opts = {}) {
         const greetList = await fetchRecommendList(page);
         const found = greetList.find((f) => f.encryptUid === encryptUid);
         if (found)
-            return found;
+            return opts.allowNonZero ? { friend: found, code: 0 } : found;
     }
-    return null;
+    return opts.allowNonZero ? { friend: null, code: 0 } : null;
 }
 // ── UI automation helpers ───────────────────────────────────────────────────
 /**
@@ -220,4 +225,109 @@ export function verbose(msg) {
     if (process.env.OPENCLI_VERBOSE) {
         console.error(`[opencli:boss] ${msg}`);
     }
+}
+// ── Geek-side helpers ────────────────────────────────────────────────────────
+export const IDENTITY_MISMATCH_CODE = 24;
+const GEEK_CHAT_URL = `https://${BOSS_DOMAIN}/web/geek/chat`;
+/**
+ * Navigate to the job-seeker chat page.
+ * Establishes the cookie + JS-global context needed for geek-side API calls.
+ */
+export async function navigateToGeekChat(page, waitSeconds = 2) {
+    await page.goto(GEEK_CHAT_URL);
+    await page.wait({ time: waitSeconds });
+}
+/**
+ * Read the encryptSystemId value required by the geek-side list API.
+ * Tries document.cookie, then window globals, then localStorage.
+ * Throws if nothing is found — caller must have navigated to the geek chat page first.
+ */
+export async function readEncryptSystemId(page) {
+    const result = await page.evaluate(`
+    (() => {
+      try {
+        const m = document.cookie.match(/encryptSystemId=([^;]+)/i);
+        if (m) return decodeURIComponent(m[1]);
+      } catch (_) {}
+      const sources = [window.__NUXT__, window.__INITIAL_STATE__];
+      for (const s of sources) {
+        if (!s) continue;
+        try {
+          const flat = JSON.stringify(s);
+          const m = flat.match(/"encryptSystemId":"([^"]+)"/);
+          if (m) return m[1];
+        } catch (_) {}
+      }
+      try {
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i);
+          if (k && k.toLowerCase().includes('encryptsystemid')) {
+            const v = localStorage.getItem(k);
+            if (v) return v;
+          }
+        }
+      } catch (_) {}
+      return '';
+    })()
+  `);
+    if (!result) {
+        throw new Error('geek 聊天页未找到 encryptSystemId（请确认已登录求职端）');
+    }
+    return result;
+}
+/**
+ * Fetch the job-seeker chat list (brief info, no securityId).
+ * Use fetchGeekFriendInfoList to enrich with securityId before calling chatmsg.
+ */
+export async function fetchGeekFriendLabelList(page, opts = {}) {
+    const labelId = opts.labelId ?? 0;
+    const encryptSystemId = opts.encryptSystemId ?? '';
+    const url = `https://${BOSS_DOMAIN}/wapi/zprelation/friend/geekFilterByLabel?labelId=${labelId}&encryptSystemId=${encodeURIComponent(encryptSystemId)}`;
+    const data = await bossFetch(page, url, { allowNonZero: opts.allowNonZero });
+    if (opts.allowNonZero && data.code !== 0) return data;
+    return data.zpData?.friendList || [];
+}
+/**
+ * Enrich a batch of geek friends with full fields including securityId.
+ * Processes in batches of 50 to avoid oversized request bodies.
+ */
+export async function fetchGeekFriendInfoList(page, friendIds = []) {
+    if (!friendIds.length) return [];
+    const BATCH_SIZE = 50;
+    const results = [];
+    for (let i = 0; i < friendIds.length; i += BATCH_SIZE) {
+        const batch = friendIds.slice(i, i + BATCH_SIZE).map(String);
+        const body = `friendIds=${batch.join(',')}`;
+        const data = await bossFetch(page, `https://${BOSS_DOMAIN}/wapi/zprelation/friend/getGeekFriendList.json`, {
+            method: 'POST',
+            body,
+        });
+        results.push(...(data.zpData?.result || []));
+    }
+    return results;
+}
+/**
+ * Find a geek-side friend by encrypted uid.
+ * Merges label-list and enriched data; returns null if not found.
+ */
+export async function findGeekFriendByUid(page, encryptUid, opts = {}) {
+    const labelList = await fetchGeekFriendLabelList(page, { encryptSystemId: opts.encryptSystemId });
+    const candidate = labelList.find((f) => f.encryptFriendId === encryptUid ||
+        String(f.uid) === String(encryptUid) ||
+        String(f.friendId) === String(encryptUid));
+    if (!candidate) return null;
+    const enriched = await fetchGeekFriendInfoList(page, [candidate.friendId]);
+    return { ...candidate, ...(enriched[0] || {}) };
+}
+/**
+ * Fetch message history for a geek-side chat.
+ * friend must have .uid (boss's numeric id) and .securityId.
+ */
+export async function fetchGeekHistoryMsg(page, friend, opts = {}) {
+    const pageNum = opts.page ?? 1;
+    const bossId = friend.uid;
+    const securityId = encodeURIComponent(friend.securityId || '');
+    const url = `https://${BOSS_DOMAIN}/wapi/zpchat/geek/historyMsg?bossId=${bossId}&securityId=${securityId}&page=${pageNum}&c=20&src=0`;
+    const data = await bossFetch(page, url);
+    return data.zpData?.messages || [];
 }

--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -239,20 +239,60 @@ export async function navigateToGeekChat(page, waitSeconds = 2) {
 }
 /**
  * Read the encryptSystemId value required by the geek-side list API.
- * Tries cookie, inline script tags, known window globals, a full window scan,
- * and localStorage. Returns empty string if not found — the API may still
- * succeed without it, and any server-side error will surface a clearer message.
+ * Strategy (in order):
+ *   1. Vue app state / Pinia stores / $route.query (Option 1 — runtime source)
+ *   2. performance.getEntriesByType('resource') — parse from geekFilterByLabel URL
+ *      that the page itself already issued (Option 2 — most deterministic)
+ *   3. cookie, inline <script> SSR state, known window globals, localStorage (fallbacks)
+ * Returns empty string if nothing is found; the API may still succeed without it.
  * Caller must have navigated to the geek chat page first.
  */
 export async function readEncryptSystemId(page) {
     const result = await page.evaluate(`
     (() => {
-      // 1. cookie
+      // 1. Vue app state / Pinia / $route.query
+      // The chat component reads encryptSystemId from the app runtime to build
+      // its own geekFilterByLabel request, so the value lives in the Vue tree.
+      try {
+        const appEl = document.querySelector('#app') || document.querySelector('[data-v-app]');
+        const vueApp = appEl && (appEl.__vue_app__ || appEl._vei);
+        if (vueApp) {
+          // 1a. Pinia stores (Vue 3 standard state management on BOSS直聘)
+          const pinia = vueApp.config && vueApp.config.globalProperties.$pinia;
+          if (pinia && pinia.state && pinia.state.value) {
+            for (const store of Object.values(pinia.state.value)) {
+              try {
+                const flat = JSON.stringify(store);
+                if (flat.includes('encryptSystemId')) {
+                  const m = flat.match(/"encryptSystemId":"([^"]+)"/);
+                  if (m) return m[1];
+                }
+              } catch (_) {}
+            }
+          }
+          // 1b. Vue Router current route query
+          const router = vueApp.config && vueApp.config.globalProperties.$router;
+          const query = router && router.currentRoute && router.currentRoute.value && router.currentRoute.value.query;
+          if (query && query.encryptSystemId) return query.encryptSystemId;
+        }
+      } catch (_) {}
+      // 2. Performance resource entries — the page already issued geekFilterByLabel
+      // with encryptSystemId in the URL; read it back from the resource timing API.
+      try {
+        const entries = performance.getEntriesByType('resource');
+        for (const entry of entries) {
+          if (!entry.name.includes('geekFilterByLabel')) continue;
+          const u = new URL(entry.name);
+          const v = u.searchParams.get('encryptSystemId');
+          if (v) return v;
+        }
+      } catch (_) {}
+      // 3. cookie
       try {
         const m = document.cookie.match(/encryptSystemId=([^;]+)/i);
         if (m) return decodeURIComponent(m[1]);
       } catch (_) {}
-      // 2. inline <script> tags (Nuxt SSR state is often embedded here)
+      // 4. inline <script> SSR state (Nuxt embeds server state here)
       try {
         for (const s of document.querySelectorAll('script:not([src])')) {
           const t = s.textContent || '';
@@ -261,7 +301,7 @@ export async function readEncryptSystemId(page) {
           if (m) return m[1];
         }
       } catch (_) {}
-      // 3. known BOSS / Nuxt window globals
+      // 5. known BOSS / Nuxt window globals
       const KNOWN = [
         '__NUXT__', '__INITIAL_STATE__', '__ZP_INFO__', '__BOSS_ZP__',
         'pageGlobalVar', 'ZP_DATA', '__ZP_DATA__', '__PAGE_DATA__',
@@ -276,22 +316,7 @@ export async function readEncryptSystemId(page) {
           if (m) return m[1];
         } catch (_) {}
       }
-      // 4. broad window scan (catches any other global holding the value)
-      try {
-        for (const k of Object.keys(window)) {
-          if (/^on|^HTML|^CSS|^SVG|^Math|^JSON|^performance/.test(k)) continue;
-          const obj = window[k];
-          if (!obj || typeof obj !== 'object') continue;
-          try {
-            const flat = JSON.stringify(obj);
-            if (flat && flat.includes('encryptSystemId')) {
-              const m = flat.match(/"encryptSystemId":"([^"]+)"/);
-              if (m) return m[1];
-            }
-          } catch (_) {}
-        }
-      } catch (_) {}
-      // 5. localStorage — any value containing the key, or key named after it
+      // 6. localStorage
       try {
         for (let i = 0; i < localStorage.length; i++) {
           const k = localStorage.key(i);

--- a/clis/boss/utils.js
+++ b/clis/boss/utils.js
@@ -239,41 +239,78 @@ export async function navigateToGeekChat(page, waitSeconds = 2) {
 }
 /**
  * Read the encryptSystemId value required by the geek-side list API.
- * Tries document.cookie, then window globals, then localStorage.
- * Throws if nothing is found — caller must have navigated to the geek chat page first.
+ * Tries cookie, inline script tags, known window globals, a full window scan,
+ * and localStorage. Returns empty string if not found — the API may still
+ * succeed without it, and any server-side error will surface a clearer message.
+ * Caller must have navigated to the geek chat page first.
  */
 export async function readEncryptSystemId(page) {
     const result = await page.evaluate(`
     (() => {
+      // 1. cookie
       try {
         const m = document.cookie.match(/encryptSystemId=([^;]+)/i);
         if (m) return decodeURIComponent(m[1]);
       } catch (_) {}
-      const sources = [window.__NUXT__, window.__INITIAL_STATE__];
-      for (const s of sources) {
-        if (!s) continue;
+      // 2. inline <script> tags (Nuxt SSR state is often embedded here)
+      try {
+        for (const s of document.querySelectorAll('script:not([src])')) {
+          const t = s.textContent || '';
+          if (!t.includes('encryptSystemId')) continue;
+          const m = t.match(/"encryptSystemId":"([^"]+)"/);
+          if (m) return m[1];
+        }
+      } catch (_) {}
+      // 3. known BOSS / Nuxt window globals
+      const KNOWN = [
+        '__NUXT__', '__INITIAL_STATE__', '__ZP_INFO__', '__BOSS_ZP__',
+        'pageGlobalVar', 'ZP_DATA', '__ZP_DATA__', '__PAGE_DATA__',
+      ];
+      for (const k of KNOWN) {
+        const obj = window[k];
+        if (!obj || typeof obj !== 'object') continue;
         try {
-          const flat = JSON.stringify(s);
+          const flat = JSON.stringify(obj);
+          if (!flat.includes('encryptSystemId')) continue;
           const m = flat.match(/"encryptSystemId":"([^"]+)"/);
           if (m) return m[1];
         } catch (_) {}
       }
+      // 4. broad window scan (catches any other global holding the value)
+      try {
+        for (const k of Object.keys(window)) {
+          if (/^on|^HTML|^CSS|^SVG|^Math|^JSON|^performance/.test(k)) continue;
+          const obj = window[k];
+          if (!obj || typeof obj !== 'object') continue;
+          try {
+            const flat = JSON.stringify(obj);
+            if (flat && flat.includes('encryptSystemId')) {
+              const m = flat.match(/"encryptSystemId":"([^"]+)"/);
+              if (m) return m[1];
+            }
+          } catch (_) {}
+        }
+      } catch (_) {}
+      // 5. localStorage — any value containing the key, or key named after it
       try {
         for (let i = 0; i < localStorage.length; i++) {
           const k = localStorage.key(i);
-          if (k && k.toLowerCase().includes('encryptsystemid')) {
+          if (!k) continue;
+          if (k.toLowerCase().includes('encryptsystemid')) {
             const v = localStorage.getItem(k);
             if (v) return v;
+          }
+          const v = localStorage.getItem(k) || '';
+          if (v.includes('encryptSystemId')) {
+            const m = v.match(/"encryptSystemId":"([^"]+)"/);
+            if (m) return m[1];
           }
         }
       } catch (_) {}
       return '';
     })()
   `);
-    if (!result) {
-        throw new Error('geek 聊天页未找到 encryptSystemId（请确认已登录求职端）');
-    }
-    return result;
+    return result || '';
 }
 /**
  * Fetch the job-seeker chat list (brief info, no securityId).


### PR DESCRIPTION
## Summary

- Adds `--side {auto|boss|geek}` option to `opencli boss chatlist` and `opencli boss chatmsg`
- `auto` (default): tries recruiter API first; falls back to job-seeker API on `code=24`
- `--side geek`: navigates to `/web/geek/chat`, reads `encryptSystemId` from page globals/cookie/localStorage, calls geek-only endpoints
- Existing recruiter behavior is fully preserved (`--side boss` or `auto` on recruiter accounts)
- No write operations introduced

## What changed

**`clis/boss/utils.js`**
- `fetchFriendList` and `findFriendByUid` gain `opts.allowNonZero` passthrough for auto-detection
- New exports: `IDENTITY_MISMATCH_CODE`, `navigateToGeekChat`, `readEncryptSystemId`, `fetchGeekFriendLabelList`, `fetchGeekFriendInfoList`, `findGeekFriendByUid`, `fetchGeekHistoryMsg`

**`clis/boss/chatlist.js`**
- `columns` expanded to 8: `[name, company, job, title, last_msg, last_time, uid, security_id]`
- `--side` choice arg added (default `auto`)
- Geek flow: `geekFilterByLabel` (brief list) → `getGeekFriendList.json` (enrich with `securityId`) → merge by `friendId`, batch 50 per POST

**`clis/boss/chatmsg.js`**
- `--side` choice arg added (default `auto`)
- Geek `from` mapping: `m.received ? '对方' : '我'`
- Non-text message bodies fall back to `JSON.stringify` (truncated to 120 chars) instead of crashing

**`clis/boss/chatlist.test.js`** (new), **`clis/boss/chatmsg.test.js`** (new)
- 12 tests total covering all issue acceptance criteria

## Test plan

```bash
npx vitest run clis/boss/chatlist.test.js clis/boss/chatmsg.test.js clis/boss/search.test.js
# → 16/16 pass

npm run typecheck -- --pretty false
# → clean
```

Manual smoke (read-only):
```bash
opencli --profile <geek-account> boss chatlist --side geek --limit 10 -f plain
opencli --profile <geek-account> boss chatmsg <uid-from-chatlist> --side geek -f plain
opencli --profile <recruiter-account> boss chatlist --side boss -f json
```

Closes #9.