### PR TITLE
feat(boss/chatmsg): add --raw to expose full JD card body

### DIFF
--- a/cli-manifest.json
+++ b/cli-manifest.json
@@ -3573,6 +3573,13 @@
           "boss",
           "geek"
         ]
+      },
+      {
+        "name": "raw",
+        "type": "boolean",
+        "default": false,
+        "required": false,
+        "help": "Return full message body including JD card payload (no 120-char truncation); extra fields appear in --fmt json/yaml"
       }
     ],
     "columns": [

--- a/clis/boss/chatmsg.js
+++ b/clis/boss/chatmsg.js
@@ -13,27 +13,37 @@ const TYPE_MAP = {
     6: '名片', 7: '语音', 8: '视频', 9: '表情',
 };
 
-function mapBossMsg(m, friend) {
+function mapBossMsg(m, friend, { raw = false } = {}) {
     const fromObj = m.from || {};
     const isSelf = typeof fromObj === 'object' ? fromObj.uid !== friend.uid : false;
-    return {
+    const row = {
         from: isSelf ? '我' : (typeof fromObj === 'object' ? fromObj.name : friend.name),
         type: TYPE_MAP[m.type] || `其他(${m.type})`,
         text: m.text || m.body?.text || '',
         time: m.time ? new Date(m.time).toLocaleString('zh-CN') : '',
     };
+    if (raw) {
+        row.security_id = m.securityId || null;
+        row.body = m.body || null;
+    }
+    return row;
 }
 
-function mapGeekMsg(m, friend) {
+function mapGeekMsg(m, friend, { raw = false } = {}) {
     const fromUid = m.from && m.from.uid;
     const isFromBoss = fromUid != null && String(fromUid) === String(friend.uid);
-    return {
+    const row = {
         from: isFromBoss ? '对方' : '我',
         type: TYPE_MAP[m.type] || `其他(${m.type})`,
         text: m.text || m.body?.text || m.body?.content || m.body?.showText ||
             JSON.stringify(m.body || {}).slice(0, 120),
         time: m.time ? new Date(m.time).toLocaleString('zh-CN') : '',
     };
+    if (raw) {
+        row.security_id = m.securityId || null;
+        row.body = m.body || null;
+    }
+    return row;
 }
 
 async function bossChatMsg(page, kwargs, existingFriend) {
@@ -51,7 +61,7 @@ async function bossChatMsg(page, kwargs, existingFriend) {
     if (messages.length === 0) {
         throw new EmptyResultError('boss chatmsg', 'Boss returned no messages for this chat.');
     }
-    return messages.map((m) => mapBossMsg(m, friend));
+    return messages.map((m) => mapBossMsg(m, friend, { raw: !!kwargs.raw }));
 }
 
 async function geekChatMsg(page, kwargs, encryptSystemId) {
@@ -59,7 +69,7 @@ async function geekChatMsg(page, kwargs, encryptSystemId) {
     if (!friend) throw new EmptyResultError('boss chatmsg', '未找到该聊天（geek 侧）');
     if (!friend.securityId) throw new CommandExecutionError('该聊天缺少 securityId，无法获取历史消息');
     const messages = await fetchGeekHistoryMsg(page, friend, { page: kwargs.page });
-    return messages.map((m) => mapGeekMsg(m, friend));
+    return messages.map((m) => mapGeekMsg(m, friend, { raw: !!kwargs.raw }));
 }
 
 cli({
@@ -75,13 +85,15 @@ cli({
         { name: 'uid', required: true, positional: true, help: 'Encrypted UID (from chatlist)' },
         { name: 'page', type: 'int', default: 1, help: 'Page number' },
         { name: 'side', default: 'auto', choices: ['auto', 'boss', 'geek'], help: 'Identity side: auto (default), boss (recruiter), or geek (job-seeker)' },
+        { name: 'raw', type: 'boolean', default: false, help: 'Return full message body including JD card payload (no 120-char truncation); extra fields appear in --fmt json/yaml' },
     ],
     columns: ['from', 'type', 'text', 'time'],
     func: async (page, kwargs) => {
         requirePage(page);
         const uid = readRequiredString(kwargs.uid, 'chatmsg uid');
         const pageNum = readPositiveInteger(kwargs.page, 'chatmsg --page', 1);
-        const normalizedKwargs = { ...kwargs, uid, page: pageNum };
+        const raw = !!kwargs.raw;
+        const normalizedKwargs = { ...kwargs, uid, page: pageNum, raw };
         const side = kwargs.side || 'auto';
 
         if (side === 'boss') {
@@ -112,6 +124,6 @@ cli({
         if (!geekFriend) throw new EmptyResultError('boss chatmsg', 'uid 在招聘端与求职端聊天列表中均未找到');
         if (!geekFriend.securityId) throw new CommandExecutionError('该聊天缺少 securityId，无法获取历史消息');
         const messages = await fetchGeekHistoryMsg(page, geekFriend, { page: pageNum });
-        return messages.map((m) => mapGeekMsg(m, geekFriend));
+        return messages.map((m) => mapGeekMsg(m, geekFriend, { raw }));
     },
 });

--- a/clis/boss/chatmsg.test.js
+++ b/clis/boss/chatmsg.test.js
@@ -209,6 +209,75 @@ describe('boss chatmsg', () => {
         ).rejects.toBeInstanceOf(CommandExecutionError);
     });
 
+    describe('--raw mode (JD card exposure)', () => {
+        // Long content (>200 chars) sits inside body.jobDesc, not body.content,
+        // so the compact-mode short-circuit (m.body?.content) does not catch it
+        // and the JSON.stringify(...).slice(0, 120) truncation branch is exercised.
+        const JD_CARD_URL = 'https://www.zhipin.com/job_detail/abc-xyz-jobid-123.html?lid=test';
+        const JD_CARD_CONTENT = '岗位职责：负责后端架构设计与核心服务开发，包括但不限于高并发、分布式系统、数据库优化、消息队列、缓存方案、监控告警、容灾备份等关键基础设施建设。任职要求：5年以上后端开发经验，精通 Java/Go，有大型互联网公司经验者优先，熟悉云原生技术栈（K8s/Docker/Service Mesh），具备良好的沟通协作能力，能承担技术攻坚任务，并在团队中起到技术引领作用。';
+        const JD_CARD_FIXTURE = {
+            type: 99,
+            received: true,
+            time: 1704067200000,
+            securityId: 'jd-sec-id-xyz',
+            from: { uid: 67890, name: 'Boss张' },
+            body: {
+                jobDesc: {
+                    title: '高级后端工程师',
+                    company: '某互联网公司',
+                    salary: '40-60K·15薪',
+                    city: '北京',
+                    content: JD_CARD_CONTENT,
+                    jobId: 'abc-xyz-jobid-123',
+                    url: JD_CARD_URL,
+                },
+            },
+        };
+
+        function buildJdPageMock(msg) {
+            return createPageMock(async (script) => {
+                if (script.includes('document.cookie')) return 'test-enc-sys-id';
+                if (script.includes('geekFilterByLabel')) {
+                    return { code: 0, zpData: { friendList: [GEEK_FRIEND_LABEL] } };
+                }
+                if (script.includes('getGeekFriendList.json')) {
+                    return { code: 0, zpData: { result: [GEEK_FRIEND_ENRICHED] } };
+                }
+                if (script.includes('geek/historyMsg')) {
+                    return { code: 0, zpData: { messages: [msg] } };
+                }
+                return {};
+            });
+        }
+
+        it('--raw exposes full JD card url (no truncation)', async () => {
+            const page = buildJdPageMock(JD_CARD_FIXTURE);
+            const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek', raw: true });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].body).toBeDefined();
+            expect(rows[0].body.jobDesc.url).toBe(JD_CARD_URL);
+            expect(rows[0].security_id).toBe('jd-sec-id-xyz');
+        });
+
+        it('--raw preserves long JD content (>120 chars)', async () => {
+            const page = buildJdPageMock(JD_CARD_FIXTURE);
+            const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek', raw: true });
+            expect(rows[0].body.jobDesc.content).toBe(JD_CARD_CONTENT);
+            expect(rows[0].body.jobDesc.content.length).toBeGreaterThan(120);
+        });
+
+        it('compact mode (no --raw) still truncates JD card body to <=120 chars and omits body/security_id', async () => {
+            const page = buildJdPageMock(JD_CARD_FIXTURE);
+            const rows = await command.func(page, { uid: 'enc-geek-uid', page: 1, side: 'geek' });
+            expect(rows).toHaveLength(1);
+            expect(rows[0].text.length).toBeLessThanOrEqual(120);
+            expect(rows[0]).not.toHaveProperty('body');
+            expect(rows[0]).not.toHaveProperty('security_id');
+            // And the full URL is NOT present in the truncated text — this is the regression #13 documents.
+            expect(rows[0].text).not.toContain(JD_CARD_URL);
+        });
+    });
+
     it('--side geek reports an empty history as EmptyResultError', async () => {
         const page = createPageMock(async (script) => {
             if (script.includes('document.cookie')) return 'test-enc-sys-id';


### PR DESCRIPTION
## Summary

`boss chatmsg --side geek` currently truncates non-text bodies to 120 chars in `mapGeekMsg`, destroying JD cards. This PR adds a `--raw` flag that emits structured per-message objects with the full `body` preserved, so callers can extract `body.jobDesc.url` and other fields needed for `boss detail`.

Closes #13.

## Changes

- `clis/boss/chatmsg.js` — add `--raw` boolean arg; both `mapBossMsg` / `mapGeekMsg` now accept `{ raw }` and append `security_id` + full `body` to the row when raw is true; threaded the flag through all four call sites (boss-side, geek-side, auto-recruiter, auto-fallback-geek)
- `clis/boss/chatmsg.test.js` — 3 new tests in a `--raw mode (JD card exposure)` block using a JD-card fixture with a long `body.jobDesc.content`
- `cli-manifest.json` — rebuilt; the new `raw` arg lands inside the `boss/chatmsg` entry

## Design notes

- **Columns unchanged** at `['from', 'type', 'text', 'time']`. `src/output.ts`'s `renderJson`/`renderYaml` ignore the `columns` array (they stringify the full object), while `renderTable`/`renderMarkdown`/`renderCsv`/`renderPlain` use it. Raw mode's extra fields therefore surface naturally in `--fmt json`/`yaml` (the intended consumption path for JD card extraction by `boss detail`) while the table view keeps showing the same four columns — no regression for existing callers
- Raw mode is a pure superset of compact output: it adds `security_id` + `body` alongside the existing four fields, doesn't replace `text`. Callers parsing JSON output continue to work
- JD fixture content placement: long `content` lives under `body.jobDesc.content` (not top-level `body.content`) so `mapGeekMsg`'s `m.body?.content` short-circuit can't catch it — this guarantees the `JSON.stringify(...).slice(0, 120)` truncation branch is exercised by the compact-mode regression test

## Test plan

- [x] `npx vitest run clis/boss/chatmsg.test.js` → 14/14 pass (11 previous + 3 new)
- [x] `npx vitest run clis/boss/` → full boss suite 29/29 pass
- [x] `npm run typecheck` → clean
- [x] `npm run build-manifest` → `raw` arg lands in `cli-manifest.json`
- [ ] Live verify on a job-seeker profile with a chat containing a JD card

🤖 Generated with [Claude Code](https://claude.com/claude-code)